### PR TITLE
Remove Latex coloring on pdf links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A collection of writeups I've made to document my progress with TryHackMe and Ha
 
 | Platform   | Room/Challenge         | Techniques/Tools                        | PDF Link                          |
 |------------|------------------------|-----------------------------------------|-----------------------------------|
-| $\textcolor{red}{\text{TryHackMe}}$   | $\textcolor{red}{\text{Blue}}$                   | $\textcolor{red}{\text{Metasploit, JTR, nmap}}$                   | $\textcolor{red}{[\text{Blue Writeup}](TryHackMe-Blue.pdf)}$ |
-| $\textcolor{red}{\text{TryHackMe}}$   | $\textcolor{red}{\text{MD2PDF}}$                 | $\textcolor{red}{\text{iframe injection, gobuster, nmap}}$         | $\textcolor{red}{[\text{MD2PDF Writeup}](TryHackMe-MD2PDF.pdf)}$ |
-| $\textcolor{red}{\text{TryHackMe}}$   | $\textcolor{red}{\text{Neighbour}}$              | $\textcolor{red}{\text{IDOR Exploit, nmap}}$                       | $\textcolor{red}{[\text{Neighbour Writeup}](TryHackMe-Neighbour.pdf)}$ |
-| $\textcolor{blue}{\text{Hack The Box}}$ | $\textcolor{blue}{\text{Brutus}}$                | $\textcolor{blue}{\text{auth.log, wtmp}}$                           | $\textcolor{blue}{[\text{Brutus Writeup}](HackTheBox-Brutus.pdf)}$ |
+| $\textcolor{red}{\text{TryHackMe}}$   | $\textcolor{red}{\text{Blue}}$                   | $\textcolor{red}{\text{Metasploit, JTR, nmap}}$                   | [Blue Writeup](TryHackMe-Blue.pdf) |
+| $\textcolor{red}{\text{TryHackMe}}$   | $\textcolor{red}{\text{MD2PDF}}$                 | $\textcolor{red}{\text{iframe injection, gobuster, nmap}}$         | [MD2PDF Writeup](TryHackMe-MD2PDF.pdf) |
+| $\textcolor{red}{\text{TryHackMe}}$   | $\textcolor{red}{\text{Neighbour}}$              | $\textcolor{red}{\text{IDOR Exploit, nmap}}$                       | [Neighbour Writeup](TryHackMe-Neighbour.pdf) |
+| $\textcolor{blue}{\text{Hack The Box}}$ | $\textcolor{blue}{\text{Brutus}}$                | $\textcolor{blue}{\text{auth.log, wtmp}}$                           | [Brutus Writeup](HackTheBox-Brutus.pdf) |


### PR DESCRIPTION
pdf links don't need to be colored differently because they are blue by default 